### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# Alpine-Golang [![Docker Stars](https://img.shields.io/docker/stars/douglarek/alpine-golang.svg?style=flat-square)](https://hub.docker.com/r/douglarek/alpine-golang/) [![Docker Pulls](https://img.shields.io/docker/pulls/douglarek/alpine-golang.svg?style=flat-square)](https://hub.docker.com/r/douglarek/alpine-golang/) [![License](https://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/douglarek/alphine-golang/master/LICENSE)
+# Alpine-Golang [![Docker Stars](https://img.shields.io/docker/stars/douglarek/alpine-golang.svg?style=flat-square)](https://hub.docker.com/r/douglarek/alpine-golang/) [![Docker Pulls](https://img.shields.io/docker/pulls/douglarek/alpine-golang.svg?style=flat-square)](https://hub.docker.com/r/douglarek/alpine-golang/) [![](https://images.microbadger.com/badges/image/douglarek/alpine-golang.svg)](https://microbadger.com/images/douglarek/alpine-golang "Get your own image badge on microbadger.com") [![License](https://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/douglarek/alphine-golang/master/LICENSE)
 
 An alphine docker image for Golang.
 
 ```
 $ docker pull douglarek/alpine-golang
 ```
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [douglarek/alpine-golang](https://hub.docker.com/r/douglarek/alpine-golang/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/douglarek/alpine-golang).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/douglarek/alpine-golang.svg)](https://microbadger.com/images/douglarek/alpine-golang "Get your own image badge on microbadger.com")
